### PR TITLE
Support for å hente token fra andre steder enn Authorization Header

### DIFF
--- a/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/MultipleJwtIssuers.kt
+++ b/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/MultipleJwtIssuers.kt
@@ -67,7 +67,7 @@ fun Authentication.Configuration.multipleJwtIssuers(
                 val token = httpAuthHeader?.decodeJwtOrNull()
                 if (token != null) logger.error("Request med token utstedt av '${token.issuer}' stoppes da issuer ikke er konfigurert. Token uten signatur = '${token.header}.${token.payload}'")
                 else {
-                    val authorizationHeader = call.request.header(HttpHeaders.Authorization)
+                    val authorizationHeader = httpAuthHeader?.render()
                     if (authorizationHeader != null) logger.error("Request med ugylidig format på Authorization header stoppes. Authorization header = '$authorizationHeader'")
                     else logger.error("Request uten Authorization header satt stoppes.")
                 }

--- a/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/MultipleJwtIssuers.kt
+++ b/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/MultipleJwtIssuers.kt
@@ -7,10 +7,8 @@ import io.ktor.auth.Authentication
 import io.ktor.auth.jwt.JWTPrincipal
 import io.ktor.auth.jwt.jwt
 import io.ktor.auth.parseAuthorizationHeader
-import io.ktor.http.HttpHeaders
 import io.ktor.http.auth.HttpAuthHeader
 import io.ktor.request.ApplicationRequest
-import io.ktor.request.header
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit

--- a/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/MultipleJwtIssuers.kt
+++ b/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/MultipleJwtIssuers.kt
@@ -20,10 +20,12 @@ private const val AUTH_SCHEME = "Bearer "
 private const val FALLBACK_ALIAS = "fallback"
 
 fun Authentication.Configuration.multipleJwtIssuers(
-        issuers : Map<Issuer, Set<ClaimRule>>
-) {
+    issuers : Map<Issuer, Set<ClaimRule>>,
+    extractHttpAuthHeader: (ApplicationCall) -> HttpAuthHeader? = { call ->
+        call.request.parseAuthorizationHeaderOrNull()
+    }) {
 
-    issuers.forEach { issuer, additionalClaimRules ->
+    issuers.forEach { (issuer, additionalClaimRules) ->
         val jwkProvider = JwkProviderBuilder(issuer.jwksUri().toURL())
                 .cached(10, 24, TimeUnit.HOURS)
                 .rateLimited(10, 1, TimeUnit.MINUTES)
@@ -41,7 +43,7 @@ fun Authentication.Configuration.multipleJwtIssuers(
             }
             authHeader { call ->
                 logger.info("Issuer[${issuer.alias()}]")
-                val httpAuthHeader = call.request.parseAuthorizationHeaderOrNull()
+                val httpAuthHeader = extractHttpAuthHeader(call)
                 val jwt = httpAuthHeader?.decodeJwtOrNull()
                 if (httpAuthHeader != null && jwt != null) {
                     logger.trace("Utfører authorization sjekk av Authorization Header.")
@@ -50,7 +52,7 @@ fun Authentication.Configuration.multipleJwtIssuers(
                 }
                 httpAuthHeader
             }
-            skipWhen { call -> call.tokenIsAbsentOrNotIssuedBy(issuer.issuer()) }
+            skipWhen { call -> tokenIsAbsentOrNotIssuedBy(extractHttpAuthHeader(call), issuer.issuer()) }
             validate { credentials -> JWTPrincipal(credentials.payload) }
         }
     }
@@ -59,9 +61,10 @@ fun Authentication.Configuration.multipleJwtIssuers(
 
     jwt(FALLBACK_ALIAS) {
         skipWhen { call ->
-            val skipping = call.tokenIsSetAndIssuerIsOneOf(configuredIssuers)
+            val httpAuthHeader = extractHttpAuthHeader(call)
+            val skipping = tokenIsSetAndIssuerIsOneOf(httpAuthHeader, configuredIssuers)
             if (!skipping) {
-                val token = call.request.parseAuthorizationHeaderOrNull()?.decodeJwtOrNull()
+                val token = httpAuthHeader?.decodeJwtOrNull()
                 if (token != null) logger.error("Request med token utstedt av '${token.issuer}' stoppes da issuer ikke er konfigurert. Token uten signatur = '${token.header}.${token.payload}'")
                 else {
                     val authorizationHeader = call.request.header(HttpHeaders.Authorization)
@@ -75,15 +78,11 @@ fun Authentication.Configuration.multipleJwtIssuers(
     }
 }
 
-private fun ApplicationCall.tokenIsAbsentOrNotIssuedBy(issuer: String): Boolean {
-    val jwt = request.parseAuthorizationHeaderOrNull()?.decodeJwtOrNull() ?: return true
-    return jwt.issuer != issuer
-}
+private fun tokenIsAbsentOrNotIssuedBy(httpAuthHeader: HttpAuthHeader?, issuer: String) =
+    httpAuthHeader?.decodeJwtOrNull()?.issuer == issuer
 
-private fun ApplicationCall.tokenIsSetAndIssuerIsOneOf(otherIssuers: List<String>): Boolean {
-    val jwt = request.parseAuthorizationHeaderOrNull()?.decodeJwtOrNull() ?: return false
-    return otherIssuers.contains(jwt.issuer)
-}
+private fun tokenIsSetAndIssuerIsOneOf(httpAuthHeader: HttpAuthHeader?, otherIssuers: List<String>) =
+    httpAuthHeader?.decodeJwtOrNull()?.issuer?.let { otherIssuers.contains(it) } ?: false
 
 private fun ApplicationRequest.parseAuthorizationHeaderOrNull() = try {
     parseAuthorizationHeader()

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <orgjson.version>20200518</orgjson.version>
 
         <!-- Interne versjoner -->
-        <oauth2-oidc-sdk.version>8.22</oauth2-oidc-sdk.version>
+        <oauth2-oidc-sdk.version>8.23</oauth2-oidc-sdk.version>
         <wiremock.version>2.27.2</wiremock.version>
     </properties>
 


### PR DESCRIPTION
Fjerne `.medValidertLevel("Level4")` fra idTokeProvider. Heller legge til en `ClaimRule` på begge issuers som sier at `acr` må være `Level4`

Deretter;

```kotlin
    val idTokenProvider = IdTokenProvider(cookieName = configuration.getCookieName())

    install(Authentication) {
        multipleJwtIssuers(
             issuers = issuers,
             extractHttpAuthHeader = { call ->
                   idTokenProvider.getIdToken(call).somHttpAuthHeader()
             }
        )
    }
```