### PR TITLE
Formaterer responsen manuelt..

### DIFF
--- a/dusseldorf-ktor-core/src/main/kotlin/no/nav/helse/dusseldorf/ktor/core/CallLoggingExt.kt
+++ b/dusseldorf-ktor-core/src/main/kotlin/no/nav/helse/dusseldorf/ktor/core/CallLoggingExt.kt
@@ -37,7 +37,7 @@ fun CallLogging.Configuration.logRequests(
 
         when (val status = it.response.status() ?: "Unhandled") {
             HttpStatusCode.Found -> "${status as HttpStatusCode}: ${it.request.httpMethod.value} -> ${it.response.headers[HttpHeaders.Location]}"
-            "Unhandled" -> "$status: ${it.request.httpMethod.value} - $path"
+            "Unhandled" -> "Unhandled: ${it.request.httpMethod.value} - $path"
             else -> "${status as HttpStatusCode}: ${it.request.httpMethod.value} - $path"
         }
     }


### PR DESCRIPTION
Formaterer responsen manuelt fordi default formatet bruker "toLogStringWithColors" som gir feil i utskrift. Skriver også om logikken som templater queryparamters, slik at vi alltid får status og httpMetode.

Eksempel på feilogg fra default metode: "[31m401 Unauthorized[m: [36mGET[m - /arbeidsgiver" 