### PR TITLE
Refaktorerer IdTokenProvider til å støtte at man henter token fra både cookie og authorization header.

### DIFF
--- a/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/AuthorizationStatusPages.kt
+++ b/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/AuthorizationStatusPages.kt
@@ -1,0 +1,44 @@
+package no.nav.helse.dusseldorf.ktor.auth
+
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.response.*
+import no.nav.helse.dusseldorf.ktor.auth.ClaimEnforcementFailed
+import no.nav.helse.dusseldorf.ktor.auth.CookieNotSetException
+import no.nav.helse.dusseldorf.ktor.auth.IdTokenInvalidFormatException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/*
+    In summary, a 401 Unauthorized response should be used for missing or bad authentication,
+    and a 403 Forbidden response should be used afterwards, when the user is authenticated but
+    isn’t authorized to perform the requested operation on the given resource.
+ */
+
+private val logger: Logger = LoggerFactory.getLogger("no.nav.helse.dusseldorf.ktor.auth.AuthorizationStatusPagesKt.IdTokenStatusPages")
+
+fun StatusPages.Configuration.IdTokenStatusPages() {
+
+    exception<ClaimEnforcementFailed> { cause ->
+        call.respond(HttpStatusCode.Forbidden)
+        // Kan ha vært logget inn på en annen NAV-tjeneste som ikke krever nivå 4 i forkant
+        // og må nå logge inn på nytt. Trenger ikke å logge noe error på dette
+        logger.trace(cause.message)
+    }
+
+    exception<CookieNotSetException> { cause ->
+        call.respond(HttpStatusCode.Unauthorized)
+        logger.trace(cause.message)
+    }
+
+    exception<UnAuthorizedException> { cause ->
+        call.respond(HttpStatusCode.Unauthorized)
+        logger.trace(cause.message)
+    }
+
+    exception<IdTokenInvalidFormatException> { cause ->
+        call.respond(HttpStatusCode.Unauthorized)
+        logger.error(cause.message)
+    }
+}

--- a/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/TokenUtils.kt
+++ b/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/TokenUtils.kt
@@ -31,18 +31,17 @@ data class IdToken(val value: String) {
 }
 
 class IdTokenProvider(
-    private val cookieName : String?,
-    private val støtteCookieOgAuthHeader: Boolean = false
+    private val cookieName : String?
 ) {
     fun getIdToken(call: ApplicationCall) : IdToken {
+        val jwt = call.request.parseAuthorizationHeader()?.render()
+        if(jwt != null) return IdToken(jwt.substringAfter("Bearer "))
+
         if(cookieName != null) {
             val cookie = call.request.cookies[cookieName]
             if(cookie != null) return IdToken(cookie)
-            if(!støtteCookieOgAuthHeader) throw CookieNotSetException(cookieName)
+            throw CookieNotSetException(cookieName)
         }
-
-        val jwt = call.request.parseAuthorizationHeader()?.render()
-        if(jwt != null) return IdToken(jwt.substringAfter("Bearer "))
 
         throw UnAuthorizedException()
     }

--- a/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/TokenUtils.kt
+++ b/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/TokenUtils.kt
@@ -44,7 +44,7 @@ class IdTokenProvider(
         val jwt = call.request.parseAuthorizationHeader()?.render()
         if(jwt != null) return IdToken(jwt.substringAfter("Bearer "))
 
-        throw NoTokenSetException()
+        throw UnAuthorizedException()
     }
 }
 
@@ -55,4 +55,4 @@ fun ApplicationCall.idToken() : IdToken {
 
 class CookieNotSetException(cookieName : String) : RuntimeException("Ingen cookie med navnet '$cookieName' satt.")
 class IdTokenInvalidFormatException(idToken: IdToken, cause: Throwable? = null) : RuntimeException("$idToken er på ugyldig format.", cause)
-class NoTokenSetException() : RuntimeException("Fant ikke token som cookie eller authorization header.")
+class UnAuthorizedException() : RuntimeException("Fant ikke token som cookie eller authorization header.")

--- a/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/TokenUtils.kt
+++ b/dusseldorf-ktor-auth/src/main/kotlin/no/nav/helse/dusseldorf/ktor/auth/TokenUtils.kt
@@ -40,7 +40,7 @@ class IdTokenProvider(
         if(cookieName != null) {
             val cookie = call.request.cookies[cookieName]
             if(cookie != null) return IdToken(cookie)
-            throw CookieNotSetException(cookieName)
+            else throw CookieNotSetException(cookieName)
         }
 
         throw UnAuthorizedException()


### PR DESCRIPTION
* Refaktorerer IdTokenProvider til å støtte at man henter token fra både cookie og auth header.
* Legger til IdTokenStatusPages som støtter UnAuthorizedException.