### PR TITLE
Håndtere JsonMappingException som kommer fra en IllegalArgumentException

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.0
-      - uses: actions/setup-java@v3.1.1
+      - uses: actions/checkout@v3.0.2
+      - uses: actions/setup-java@v3.3.0
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.0.0
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master


### PR DESCRIPTION
Ved bruk av require i init som gir feil så kastes IllegalArgumentException. Legger til støtte slik at man kan gi nøyaktig feilmelding på hva og hvor det gikk galt.