### PR TITLE
Setter netty-handler eksplisitt da repoer som importerer dusseldorf-ktor trekker inn en gammel versjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-kqueue</artifactId>
                 <version>${netty.version}</version>
             </dependency>


### PR DESCRIPTION
Ref sårbarheter 
https://github.com/navikt/omsorgspenger-tilgangsstyring/security/dependabot/13
https://github.com/navikt/k9-personopplysninger/security/dependabot/19
https://github.com/navikt/omsorgspenger-sak/security/dependabot/16
https://github.com/navikt/omsorgspenger-infotrygd-rammevedtak/security/dependabot/14
https://github.com/navikt/k9-vaktmester/security/dependabot/17