### PR TITLE
Endrer navngiving på metoder for tydeliggjøre når det er OBO og når det er CC som etterspørres

### DIFF
--- a/dusseldorf-oauth2-client/src/main/kotlin/no/nav/helse/dusseldorf/oauth2/client/AccessTokenClient.kt
+++ b/dusseldorf-oauth2-client/src/main/kotlin/no/nav/helse/dusseldorf/oauth2/client/AccessTokenClient.kt
@@ -1,8 +1,18 @@
 package no.nav.helse.dusseldorf.oauth2.client
 
 interface AccessTokenClient {
-    fun getAccessToken(scopes: Set<String>, onBehalfOf: String) : AccessTokenResponse
-    fun getAccessToken(scopes: Set<String>) : AccessTokenResponse
+    fun getOnBehalfOfAccessToken(scopes: Set<String>, onBehalfOf: String) : AccessTokenResponse
+    fun getClientCredentialsAccessToken(scopes: Set<String>) : AccessTokenResponse
+
+    @Deprecated("Bruk getOnBehalfOfAccessToken eller getClientCredentialsAccessToken", level = DeprecationLevel.ERROR)
+    fun getAccessToken(scopes: Set<String>, onBehalfOf: String) : AccessTokenResponse {
+        return getOnBehalfOfAccessToken(scopes, onBehalfOf)
+    }
+
+    @Deprecated("Bruk getOnBehalfOfAccessToken eller getClientCredentialsAccessToken", level = DeprecationLevel.ERROR)
+    fun getAccessToken(scopes: Set<String>) : AccessTokenResponse {
+        return getClientCredentialsAccessToken(scopes)
+    }
 }
 
 // https://tools.ietf.org/html/rfc6749#section-4.4.3 - A refresh token SHOULD NOT be included

--- a/dusseldorf-oauth2-client/src/main/kotlin/no/nav/helse/dusseldorf/oauth2/client/CachedAccessTokenClient.kt
+++ b/dusseldorf-oauth2-client/src/main/kotlin/no/nav/helse/dusseldorf/oauth2/client/CachedAccessTokenClient.kt
@@ -22,18 +22,18 @@ class CachedAccessTokenClient(
             .maximumSize(maxCachedOnBehalfOfAccessTokens)
             .build()
 
-    fun getAccessToken(
+    fun getOnBehalfOfAccessToken(
             scopes: Set<String>,
             onBehalfOf: String): AccessToken {
         val response = onBehalfOfTokens.get(Key(scopes, onBehalfOf)) {
-            accessTokenClient.getAccessToken(scopes, onBehalfOf)
+            accessTokenClient.getOnBehalfOfAccessToken(scopes, onBehalfOf)
         }
         return AccessToken(token = response!!.accessToken, type = response.tokenType)
     }
-    fun getAccessToken(
+    fun getClientCredentialsAccessToken(
             scopes: Set<String>): AccessToken {
         val response = clientAccessTokens.get(Key(scopes)) {
-            accessTokenClient.getAccessToken(scopes)
+            accessTokenClient.getClientCredentialsAccessToken(scopes)
         }
         return AccessToken(token = response!!.accessToken, type = response.tokenType)
     }

--- a/dusseldorf-oauth2-client/src/main/kotlin/no/nav/helse/dusseldorf/oauth2/client/ClientSecretAccessTokenClient.kt
+++ b/dusseldorf-oauth2-client/src/main/kotlin/no/nav/helse/dusseldorf/oauth2/client/ClientSecretAccessTokenClient.kt
@@ -28,12 +28,12 @@ class ClientSecretAccessTokenClient(
         )
     }
 
-    override fun getAccessToken(
+    override fun getOnBehalfOfAccessToken(
             scopes: Set<String>,
             onBehalfOf: String
     ): AccessTokenResponse = getAccessToken(getOnBehalfOfTokenRequest(onBehalfOf, scopes))
 
-    override fun getAccessToken(
+    override fun getClientCredentialsAccessToken(
             scopes: Set<String>
     ): AccessTokenResponse = getAccessToken(getClientCredentialsTokenRequest(scopes))
 

--- a/dusseldorf-oauth2-client/src/main/kotlin/no/nav/helse/dusseldorf/oauth2/client/SignedJwtAccessTokenClient.kt
+++ b/dusseldorf-oauth2-client/src/main/kotlin/no/nav/helse/dusseldorf/oauth2/client/SignedJwtAccessTokenClient.kt
@@ -42,11 +42,11 @@ class SignedJwtAccessTokenClient(
     }
 
 
-    override fun getAccessToken(scopes: Set<String>): AccessTokenResponse {
+    override fun getClientCredentialsAccessToken(scopes: Set<String>): AccessTokenResponse {
         return getAccessToken(getClientCredentialsTokenRequest(scopes))
     }
 
-    override fun getAccessToken(scopes: Set<String>, onBehalfOf: String): AccessTokenResponse {
+    override fun getOnBehalfOfAccessToken(scopes: Set<String>, onBehalfOf: String): AccessTokenResponse {
         return when (onBehalfOfGrantType) {
             GrantType.JwtBearer -> getAccessToken(getOnBehalfOfJwtBearerTokenRequest(onBehalfOf, scopes))
             GrantType.TokenExchange -> getAccessToken(getOnBehalfOfTokenExchangeTokenRequest(onBehalfOf, scopes))

--- a/dusseldorf-oauth2-client/src/test/kotlin/no/nav/helse/dusseldorf/oauth2/client/CachedAccessTokenClientTest.kt
+++ b/dusseldorf-oauth2-client/src/test/kotlin/no/nav/helse/dusseldorf/oauth2/client/CachedAccessTokenClientTest.kt
@@ -28,16 +28,16 @@ class CachedAccessTokenClientTest {
         mock.stubGetTokenClientSecretClientCredentials(clientId, clientSecret, expiresIn = leewayInSeconds + 1, accessToken = "Token1")
 
         // Henter første token
-        assertEquals("Token1", cachedClient.getAccessToken(scopes).token)
+        assertEquals("Token1", cachedClient.getClientCredentialsAccessToken(scopes).token)
 
         // Venter slikat tokene fortsatt bør være cached
         Thread.sleep(500)
-        assertEquals(cachedClient.getAccessToken(scopes).token, "Token1")
+        assertEquals(cachedClient.getClientCredentialsAccessToken(scopes).token, "Token1")
 
         // Venter slik at tokenet bør være bort fra cache
         Thread.sleep(700)
         // Mocker ny response med nytt token
         mock.stubGetTokenClientSecretClientCredentials(clientId, clientSecret, expiresIn = leewayInSeconds + 1, accessToken = "Token2")
-        assertEquals("Token2",cachedClient.getAccessToken(scopes).token)
+        assertEquals("Token2",cachedClient.getClientCredentialsAccessToken(scopes).token)
     }
 }

--- a/dusseldorf-oauth2-client/src/test/kotlin/no/nav/helse/dusseldorf/oauth2/client/ClientSecretAccessTokenClientTest.kt
+++ b/dusseldorf-oauth2-client/src/test/kotlin/no/nav/helse/dusseldorf/oauth2/client/ClientSecretAccessTokenClientTest.kt
@@ -23,7 +23,7 @@ class ClientSecretAccessTokenClientTest {
                 tokenEndpoint = TestData.AZURE_PREPROD_TOKEN_URL
         )
 
-        val accessToken = client.getAccessToken(scopes)
+        val accessToken = client.getClientCredentialsAccessToken(scopes)
 
         val jwt = SignedJWT.parse(accessToken.accessToken)
         println(jwt.parsedString)
@@ -47,7 +47,7 @@ class ClientSecretAccessTokenClientTest {
                 tokenEndpoint = tokenUrl
         )
 
-        val resp = client.getAccessToken(
+        val resp = client.getClientCredentialsAccessToken(
                 scopes = setOf("en-annen-client/.default")
         )
 
@@ -67,7 +67,7 @@ class ClientSecretAccessTokenClientTest {
                 tokenEndpoint = URI(wireMock.getAzureV2TokenUrl())
         )
 
-        val response = client.getAccessToken(setOf("fooscope/.default"))
+        val response = client.getClientCredentialsAccessToken(setOf("fooscope/.default"))
 
         assertNotNull(response)
         wireMock.stop()

--- a/dusseldorf-oauth2-client/src/test/kotlin/no/nav/helse/dusseldorf/oauth2/client/SignedJwtAccessTokenClientTest.kt
+++ b/dusseldorf-oauth2-client/src/test/kotlin/no/nav/helse/dusseldorf/oauth2/client/SignedJwtAccessTokenClientTest.kt
@@ -31,7 +31,7 @@ class SignedJwtAccessTokenClientTest {
                 privateKeyProvider = FromJwk(privateKeyJwk)
         )
 
-        val accessToken = client.getAccessToken(scopes)
+        val accessToken = client.getClientCredentialsAccessToken(scopes)
 
         val jwt = SignedJWT.parse(accessToken.accessToken)
         println(jwt.parsedString)
@@ -54,7 +54,7 @@ class SignedJwtAccessTokenClientTest {
                 privateKeyProvider = FromJwk(TestData.PRIVATE_KEY_JWK)
         )
 
-        val resp = client.getAccessToken(
+        val resp = client.getClientCredentialsAccessToken(
                 scopes = setOf("en-annen-client/.default")
         )
 
@@ -75,7 +75,7 @@ class SignedJwtAccessTokenClientTest {
                 privateKeyProvider = FromJwk(TestData.PRIVATE_KEY_JWK)
         )
 
-        val response = client.getAccessToken(setOf("fooscope/.default"))
+        val response = client.getClientCredentialsAccessToken(setOf("fooscope/.default"))
 
         assertNotNull(response)
         wireMock.stop()
@@ -98,7 +98,7 @@ class SignedJwtAccessTokenClientTest {
             fnr = "12345566"
         )
 
-        val response = client.getAccessToken(setOf("min-test-app-b"), onBehalfOf)
+        val response = client.getOnBehalfOfAccessToken(setOf("min-test-app-b"), onBehalfOf)
 
         val claims = SignedJWT.parse(response.accessToken).jwtClaimsSet
 


### PR DESCRIPTION
### Behov / Bakgrunn

Det er nødvendig å skille navnene for å enklere se i code review hvilket token som hentes.

### Løsning

Endrer navngiving på metoder for tydeliggjøre når det er OBO og når det er CC som etterspørres. Lar de gamle metodene ligge med @Deprecated(ERROR) for å kunne gi melding til den som skal ta inn endringen får et hint om hva som skal gjøres.

### Andre endringer

