### PR TITLE
Velg spesifikk versjon av jackson 3 for å unngå sårbarheter

### DIFF
--- a/dusseldorf-ktor-auth/pom.xml
+++ b/dusseldorf-ktor-auth/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dusseldorf-ktor-jackson/pom.xml
+++ b/dusseldorf-ktor-jackson/pom.xml
@@ -32,8 +32,8 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
+
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,8 @@
         <!-- kan ikke gå for 2.1 fordi ktor.versjon 2.3 importerer kotlin-stdlib-common, og den er ikke tilgjengelig i nyere kotlin-stdlib-versjoner -->
         <kotlin.version>2.3.21</kotlin.version>
 
-        <jackson.version>2.21.2</jackson.version>
+        <jackson2.version>2.21.2</jackson2.version>
+        <jackson3.version>3.1.3</jackson3.version>
         <ktor.version>3.5.0</ktor.version>
         <micrometer.version>1.16.5</micrometer.version>
         <logback.version>1.5.34</logback.version>
@@ -140,14 +141,18 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson2.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>2.21</version>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Behov / Bakgrunn
Holde seg oppdatert, unngå sårbarheter. Jackson 3 dras inn transitivt fra bl.a. logback

### Løsning

Setter versjon i dependency management

### Andre endringer

