### PR TITLE
Logg mer detaljer om uhåndtert feil så det er enklere å se i loggen

### DIFF
--- a/dusseldorf-ktor-core/src/main/kotlin/no/nav/helse/dusseldorf/ktor/core/DefaultStatusPages.kt
+++ b/dusseldorf-ktor-core/src/main/kotlin/no/nav/helse/dusseldorf/ktor/core/DefaultStatusPages.kt
@@ -23,7 +23,7 @@ fun StatusPagesConfig.DefaultStatusPages() {
         if (cause is Problem) {
             call.respondProblemDetails(cause.getProblemDetails(), logger, cause)
         } else {
-            logger.error("Uhåndtert feil", cause)
+            logger.error("Uhåndtert feil: ${cause.message?.take(1000)}", cause)
             call.respondProblemDetails(UNHANDLED_PROBLEM_MESSAGE, logger, cause)
         }
     }


### PR DESCRIPTION
### Behov / Bakgrunn
Det er unødvendig skjult hva som er problemet når det oppstår en 'Uhåndtert feil'

### Løsning
Ta også med message fra exception, men maks 1000 tegn for å ha logginnslag som håndteres fint av rammeverkene

### Andre endringer

